### PR TITLE
Buy Weapon License Fix and corrected typo

### DIFF
--- a/esx_inventoryhud/client/main.lua
+++ b/esx_inventoryhud/client/main.lua
@@ -613,7 +613,7 @@ Citizen.CreateThread(function()
 					end
 				end
             end
-            if IsDisabledControlJustReleased(1, 166) then
+            if IsDisabledControlJustReleased(1, 165) then
                 if fastWeapons[5] ~= nil then
 					if GetSelectedPedWeapon(GetPlayerPed(-1)) == GetHashKey(fastWeapons[5]) then
 						SetCurrentPedWeapon(GetPlayerPed(-1), "WEAPON_UNARMED",true)

--- a/esx_inventoryhud/server/main.lua
+++ b/esx_inventoryhud/server/main.lua
@@ -386,7 +386,7 @@ RegisterServerEvent('suku:buyLicense')
 AddEventHandler('suku:buyLicense', function ()
 	local _source = source
 	local xPlayer = ESX.GetPlayerFromId(source)
-	if xPlayer.get('money') >= Config.LicensePrice then
+	if xPlayer.getMoney() >= Config.LicensePrice then
 		xPlayer.removeMoney(Config.LicensePrice)
 		TriggerClientEvent('mythic_notify:client:SendAlert', source, { type = 'success', text = 'You registered a Fire Arms license.' })
 		TriggerEvent('esx_license:addLicense', _source, 'weapon', function ()


### PR DESCRIPTION
Fixes error that prevents the player from buying a weapon license and was giving the following console error: `SCRIPT ERROR: @esx_inventoryhud/server/main.lua:389: attempt to compare number with nil`